### PR TITLE
Catalog View: Restore Dep Graph Links

### DIFF
--- a/js/catalog.js
+++ b/js/catalog.js
@@ -315,7 +315,7 @@ function renderRepoListHtml() {
         <span class="fa fa-code-fork"></span> ${repo.forks}
       </a>
       <a href="/explore/spack-dependencies/?package=${repo.name}" title="Dependency Network">
-        <span class="fa fa-code-github"></span>
+        <span class="fa fa-pie-chart"></span>
       </a>
       ${
         repo.homepageUrl

--- a/js/explore/dependencies/force_spackGraph.js
+++ b/js/explore/dependencies/force_spackGraph.js
@@ -181,7 +181,7 @@ function draw_force_graph(areaID, adjacentAreaID) {
 
     if (package_queried) {
       const package = urlParams.get('package');
-      draw_variant_picker(d);
+      draw_variant_picker(package);
       redraw_for_package(package);
     }
     else {


### PR DESCRIPTION
#2 Added links from the catalog view to the Spack dep graph, but the icons(and links) were not rendered.
This PR allows them to render (and chooses a better icon) and additionally patches a bug discovered in the package query interface of the dep graph.