### PR TITLE
Removed the orphaned spack submodule from the git index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ _explore/LAST_MASTER_UPDATE.log
 /_explore/github-data/
 .bundle
 
+# Spack directory created by GitHub Actions workflow
+spack/
+
 ### Jekyll ###
 _site/
 /public/


### PR DESCRIPTION
Added spack/ to .gitignore to prevent it from being re-added