### PR TITLE
Fix invalid JSON in catalog/category_info.json that breaks catalog page

### DIFF
--- a/catalog/category_info.json
+++ b/catalog/category_info.json
@@ -7,7 +7,7 @@
         "alt": "Data and Visualization"
       },
       "description": {
-        "short": "Manage visualizations with robust features and configurable analysis",
+        "short": "Provide capabilities for analyzing, visualizing, compressing, moving, and managing data",
         "long": ""
       },
       "topics": [
@@ -63,7 +63,7 @@
         "alt": "Mathematical Libraries"
       },
       "description": {
-        "short": "Robust mathematical techniques and numerical algorithms to reliably address the challenges of large-scale simulation of complex physical phenomena,
+        "short": "Scalable libraries supporting the latest HPC architectures for coupled systems, ensemble calculations, and more",
         "long": ""
       },
       "topics": [
@@ -84,7 +84,7 @@
         "alt": "Programming Models and Runtimes"
       },
       "description": {
-        "short": "Programming Systems are the first point of contact in human-computer interactions, and never ceased to evolve along with hardware and software technology",
+        "short": "Support intra-node and inter-node concurrency on current and next-generation HPC node architectures",
         "long": ""
       },
       "topics": [


### PR DESCRIPTION
The Mathematical Libraries description had a missing closing quote, causing the JSON to be malformed. This prevented the catalog JavaScript from loading the category data, leaving all content hidden.

This fixes the catalog display at https://corsa.center/dashboard/catalog/