### PR TITLE
Fixup Spack Dependency Updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,12 +18,12 @@ jobs:
           python-version: '3.10'
       - run: pip install -r _explore/scripts/requirements.txt
       - name: Setup Spack # Spack is not yet pip installable, so we must install via the actions
-        uses: spack/setup-spack@v2
+        uses: spack/setup-spack@16b756799ede8b28951287f89bcd3fdb32ec1ca3
         with:
-          ref: develop-2025-04-13
+          spack_ref: releases/v1.1.1
           buildcache: false
           color: false
-          path: spack
+          spack_path: spack
       - name: Run update script
         run:
           ./_explore/scripts/UPDATE.sh

--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -19,7 +19,7 @@
             "anlsys/aml",
             "amrex-codes/amrex",
             "alpine-dav/ascent",
-            "berkeleylab/caffeine/releases",
+            "berkeleylab/caffeine",
             "chip-spv/chipstar",
             "darshan-hpc/darshan",
             "deephyper/deephyper",

--- a/_explore/scripts/UPDATE.sh
+++ b/_explore/scripts/UPDATE.sh
@@ -35,7 +35,7 @@ function runScript() {
 # Basic script run procedure but make it Spack
 function runSpackScript() {
     echo "Run - $1"
-    spack python "$@"
+    spack -d python "$@"
     ret=$?
     errorCheck "$1"
 }

--- a/_explore/scripts/get_cass_projects.py
+++ b/_explore/scripts/get_cass_projects.py
@@ -104,6 +104,7 @@ if response.status_code == 200:
                         if github_match:
                             part_after_url = github_match.group(2).strip().lstrip('/').lower()
                             part_after_url = re.sub(r'\.git$', '', part_after_url)
+                            part_after_url = re.sub(r'\releases', '', part_after_url)
                             if part_after_url.endswith('/'):
                                 part_after_url = part_after_url[:-1]
                             github_list.append((part_after_url))


### PR DESCRIPTION
An attempt to fix the failing update pipelines

* Updates Spack checkout action usage and version
* Fixes input_lists.json that was improperly formatted post #34 
  * The repo `caffeine` was listed as `berkeleylab/caffeine/releases` which broke the expected scheme and parsing from the Spack script. Picking up the releases branch is not really what this is tracking either.
* For whatever reason, Caffeine's url was updated upstream in [ad989efcb6eeeeb22bee014b3eebfa39b4038fb7](https://github.com/cass-community/cass-community.github.io/commit/ad989efcb6eeeeb22bee014b3eebfa39b4038fb7) to include the releases page. This was not pruned by our `get_cass_projects.py` and added the unsantized url with `/releases` at the end of the string to the input_lists.json, breaking the Spack dependency updates. Fixed the get cass projects scripts to better sanitize future inputs.
