### PR TITLE
Correct "Setup Spack" action usage

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Spack # Spack is not yet pip installable, so we must install via the actions
         uses: spack/setup-spack@16b756799ede8b28951287f89bcd3fdb32ec1ca3
         with:
-          spack_ref: releases/v1.1.1
+          spack_ref: v1.1.1
           buildcache: false
           color: false
           spack_path: spack


### PR DESCRIPTION
According to the docs (verified by local testing) the correct way to reference a ref like `v1.1.1` is `releases/v1.1.1`, however this doesn't seem to work in CI, but simply using `v1.1.1` does.

This PR just uses `v1.1.1` vs also specifying the releases denotation.

We're pinned to a specific sha of the action so we don't need to worry about this changing from beneath us.