### PR TITLE
Ensure repo urls point to actual repository

### DIFF
--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -19,7 +19,7 @@
             "anlsys/aml",
             "amrex-codes/amrex",
             "alpine-dav/ascent",
-            "berkeleylab/caffeine/releases",
+            "berkeleylab/caffeine",
             "chip-spv/chipstar",
             "darshan-hpc/darshan",
             "deephyper/deephyper",

--- a/_explore/scripts/get_cass_projects.py
+++ b/_explore/scripts/get_cass_projects.py
@@ -104,7 +104,7 @@ if response.status_code == 200:
                         if github_match:
                             part_after_url = github_match.group(2).strip().lstrip('/').lower()
                             part_after_url = re.sub(r'\.git$', '', part_after_url)
-                            part_after_url = re.sub(r'\releases', '', part_after_url)
+                            part_after_url = re.sub(r'/releases$', '', part_after_url)
                             if part_after_url.endswith('/'):
                                 part_after_url = part_after_url[:-1]
                             github_list.append((part_after_url))


### PR DESCRIPTION
Updates parsing in `get_cass_projects.py` to handle when projects specify release pages as their url. 