### PR TITLE
Fix KeyError crash and docker-image submodule error

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/_explore/scripts/gather_repo_metadata.py
+++ b/_explore/scripts/gather_repo_metadata.py
@@ -24,11 +24,11 @@ for repo in genDataCollector.data["data"]:
     repoObj = genDataCollector.data["data"][repo]
 
     repoData["name"] = repo
-    repoData["description"] = repoObj["description"]
-    repoData["website"] = repoObj["homepageUrl"]
+    repoData["description"] = repoObj.get("description")
+    repoData["website"] = repoObj.get("homepageUrl")
 
     # gather any repo topics
-    if repoObj["repositoryTopics"]["totalCount"] > 0:
+    if repoObj.get("repositoryTopics") and repoObj["repositoryTopics"]["totalCount"] > 0:
         topicRepo = topicsCollector.data["data"][repo]
         topics = []
         for topicObj in topicRepo["repositoryTopics"]["nodes"]:


### PR DESCRIPTION
## Summary

- **`gather_repo_metadata.py`**: Use `.get()` for `repositoryTopics`, `description`, and `homepageUrl` to handle repos where GraphQL queries failed and returned incomplete data. Previously crashed with `KeyError: 'repositoryTopics'` (seen in [run 23860507411](https://github.com/corsa-center/dashboard/actions/runs/23860507411)).
- **`docker-image.yml`**: Add `submodules: false` to the checkout step to match the other workflows. The `spack-packages` submodule entry has no `.gitmodules` URL, causing the build to fail on checkout.

## Test plan (onced merged)
- [ ] Re-run the `update` workflow and confirm no `KeyError` crash in `gather_repo_metadata.py`
- [ ] Re-run the `docker-image` workflow and confirm checkout succeeds