### PR TITLE
Fetch sustainability metrics from metrics repo artifact

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,6 +24,23 @@ jobs:
           buildcache: false
           color: false
           spack_path: spack
+      - name: Download sustainability metrics from metrics repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Download the latest sustainability-metrics artifact from corsa-center/metrics
+          ARTIFACT_URL=$(gh api repos/corsa-center/metrics/actions/artifacts \
+            --jq '[.artifacts[] | select(.name == "sustainability-metrics" and .expired == false)] | sort_by(.created_at) | last | .archive_download_url')
+
+          if [ -n "$ARTIFACT_URL" ] && [ "$ARTIFACT_URL" != "null" ]; then
+            echo "Downloading metrics artifact..."
+            gh api "$ARTIFACT_URL" > /tmp/metrics.zip
+            unzip -o /tmp/metrics.zip -d explore/github-data/
+            echo "Sustainability metrics updated"
+          else
+            echo "::warning::No sustainability-metrics artifact found in corsa-center/metrics"
+          fi
+
       - name: Run update script
         run:
           ./_explore/scripts/UPDATE.sh


### PR DESCRIPTION
## Summary
- Adds a step to the daily `update.yml` workflow that downloads the latest `sustainability-metrics` artifact from `corsa-center/metrics`
- Places `sustainabilityMetrics.json` into `explore/github-data/` before the existing update script runs
- Decouples metrics data from the dashboard repo — no direct pushes from the metrics side needed

## How it works
1. `corsa-center/metrics` runs its weekly collection workflow and uploads `sustainabilityMetrics.json` as a GitHub Actions artifact (90-day retention)
2. This dashboard workflow downloads the latest artifact via `gh api` and unzips it into the data directory
3. The existing commit/merge steps pick up the new file along with other data updates

## Test plan
- [ ] Verify the metrics workflow in `corsa-center/metrics` produces the `sustainability-metrics` artifact
- [ ] Trigger the dashboard update workflow manually and confirm `sustainabilityMetrics.json` is downloaded
- [ ] Verify the sustainability metrics section renders on a repo detail page (e.g. HDFGroup/hdf5)