### PR TITLE
Fix KeyError when repo missing from topics data in gather_repo_metadata.py

### DIFF
--- a/_explore/scripts/gather_repo_metadata.py
+++ b/_explore/scripts/gather_repo_metadata.py
@@ -28,8 +28,8 @@ for repo in genDataCollector.data["data"]:
     repoData["website"] = repoObj.get("homepageUrl")
 
     # gather any repo topics
-    if repoObj.get("repositoryTopics") and repoObj["repositoryTopics"]["totalCount"] > 0:
-        topicRepo = topicsCollector.data["data"][repo]
+    topicRepo = topicsCollector.data["data"].get(repo)
+    if repoObj.get("repositoryTopics") and repoObj["repositoryTopics"]["totalCount"] > 0 and topicRepo:
         topics = []
         for topicObj in topicRepo["repositoryTopics"]["nodes"]:
             topics.append(topicObj["topic"]["name"])


### PR DESCRIPTION
## Summary
- `gather_repo_metadata.py` was crashing with `KeyError: 'pmodels/mpich'` because it used direct dict access (`topicsCollector.data["data"][repo]`) for a repo that exists in `intReposInfo.json` but is absent from `intRepos_Topics.json`
- Fixed by using `.get(repo)` and guarding the topics loop with a `topicRepo` check, so missing repos gracefully fall back to `topics: null`

## Test plan
- [ ] Confirm the GitHub Actions `update` job completes without `KeyError` after this change
- [ ] Verify repos with valid topics still populate correctly in `intRepo_Metadata.json`