### PR TITLE
Fix Node.js 20 deprecation warnings in pages.yml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Build job
   build:
@@ -38,7 +41,7 @@ jobs:
         with:
           submodules: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@086ffb1a2090c870a3f881cc91ea83aa4243d408 # v1.195.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
## Summary

- Unpins `ruby/setup-ruby` from the SHA-pinned `v1.195.0` to the floating `v1` tag so it picks up the latest Node 24-compatible release automatically
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow-level env var to opt all actions into Node.js 24 now, ahead of the forced migration on **June 16, 2026**

## Motivation

GitHub Actions run 26980684864 showed deprecation warnings for all actions running on Node.js 20 (`actions/checkout`, `configure-pages`, `upload-pages-artifact`, `deploy-pages`, `ruby/setup-ruby`). Node.js 20 will be forced to Node.js 24 on June 16, 2026 and removed September 16, 2026.

## Test plan
- [ ] Verify pages workflow runs without Node.js 20 deprecation warnings after merge