### PR TITLE
Fix update.yml: clear existing metrics before artifact download

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -41,6 +41,9 @@ jobs:
             exit 0
           fi
 
+          echo "Clearing existing metrics files before download"
+          rm -rf explore/github-data/*-metrics/
+
           echo "Downloading sustainability-metrics artifact from run $RUN_ID"
           gh run download "$RUN_ID" \
             --repo corsa-center/metrics \


### PR DESCRIPTION
The `gh run download` command fails with 'file exists' when metrics directories are already present on the `update` branch from a prior run. Adding `rm -rf explore/github-data/*-metrics/` before the download fixes this.