### PR TITLE
Fix update.yml: force-sync metrics files overriding historic deletion

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -83,6 +83,16 @@ jobs:
           git branch --set-upstream-to=origin/"${DEPLOY_BRANCH}" "${DEPLOY_BRANCH}"
           git pull
           git merge "${UPDATE_BRANCH}"
+
+          # Force-include metrics files from the update branch.
+          # A prior explicit deletion in main causes git merge to skip them;
+          # checking them out directly overrides that.
+          git checkout "${UPDATE_BRANCH}" -- explore/github-data/
+          git add explore/github-data/
+          if ! git diff --staged --quiet; then
+            git commit -m "Sync metrics files from ${UPDATE_BRANCH} branch"
+          fi
+
           git push --set-upstream origin "${DEPLOY_BRANCH}"
         env:
           DEPLOY_BRANCH: ${{ vars.DEPLOY_BRANCH }}


### PR DESCRIPTION
The 63 package metrics files were explicitly deleted from main in a prior commit (`28d7e3e7`). Git merge respects that deletion and skips re-adding the files from the update branch even when they exist there.

Fix: after the merge, explicitly `git checkout ${UPDATE_BRANCH} -- explore/github-data/` to force-include the metrics files regardless of deletion history.