### PR TITLE
Fix update.yml: use -X theirs to auto-resolve merge conflicts

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -82,7 +82,7 @@ jobs:
           git checkout "${DEPLOY_BRANCH}"
           git branch --set-upstream-to=origin/"${DEPLOY_BRANCH}" "${DEPLOY_BRANCH}"
           git pull
-          git merge "${UPDATE_BRANCH}"
+          git merge "${UPDATE_BRANCH}" -X theirs
 
           # Force-include metrics files from the update branch.
           # A prior explicit deletion in main causes git merge to skip them;


### PR DESCRIPTION
The merge from `update` → `main` fails when auto-generated files (e.g. `intRepos_Dependencies.json`) have concurrent modifications. Adding `-X theirs` resolves all conflicts automatically by preferring the update branch's version, which is correct for auto-generated data files.