### PR TITLE
Fix detail panel text-align inherited from .text-center wrapper

### DIFF
--- a/css/metrics.scss
+++ b/css/metrics.scss
@@ -419,6 +419,7 @@
 .pw-detail-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
 
 .pw-detail-body {
+  text-align: left;
   p { margin: 4px 0; }
   strong { color: #1e293b; }
   a { color: #0284c7; }


### PR DESCRIPTION
The `#metrics-section` is wrapped in `<div class="text-center">` in the single-repo HTML, which causes Bootstrap's `text-align: center` to inherit into `.pw-detail-body`. The sub-detail indentation (`margin-left: 18px`) was applying correctly but the centered text made it invisible. Adding `text-align: left` to `.pw-detail-body` fixes it.